### PR TITLE
add local declaration of _ to getargs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -836,7 +836,7 @@ local function debugger_loop(ev, vars, file, line, idx_watch)
   
   local function getargs(spec)
     local res={}
-    local char,arg
+    local char,arg,_
     local ptr=1
     for i=1,string.len(spec) do
       char = string.sub(spec,i,i)


### PR DESCRIPTION
was messing up trying to get help on on scilua/luajit with this stacktrace:

[LDB]> h
/home/jlamar/app/ulua/luajit/2_1_head20151128/Linux/x64/luajit: /home/jlamar/app/ulua/luadbg/0_1+103/init.lua:860: assign to undeclared variable '_'
stack traceback:
        [C]: in function 'error'
        ...ar/app/ulua/luajit/2_1_head20151128/Linux/x64/strict.lua:28: in function '__newindex'
        /home/jlamar/app/ulua/luadbg/0_1+103/init.lua:860: in function 'getargs'
        /home/jlamar/app/ulua/luadbg/0_1+103/init.lua:1160: in function 'debugger_loop'
        /home/jlamar/app/ulua/luadbg/0_1+103/init.lua:1267: in function </home/jlamar/app/ulua/luadbg/0_1+103/init.lua:1215>
        /home/jlamar/app/ulua/pkg/1_0_beta10/init.lua:204: in function 'load'
        sim_exp.lua:30: in function 'fn'
        ...mar/app/ulua/bin/../sci-lang/1_0_beta10/__bin/scilua.lua:77: in main chunk
        [C]: at 0x004057d0